### PR TITLE
Don’t increment counter on pre run.

### DIFF
--- a/app.js
+++ b/app.js
@@ -75,7 +75,9 @@ var Transformations = {
       var number = 10;
     }
     return function(row, idx){
-      if(lines < number){
+      if(idx == 'pre'){
+        return null;
+      }else if(lines < number){
         lines += 1;
         return row
       }else{


### PR DESCRIPTION
Fixes #43.

Also, update default to 10 lines, to match docs.
