### PR TITLE
Add range function to cut

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,6 +41,22 @@ env.express(app);
 
 function noop(arg){return arg}
 
+function toIntArr(str){
+  var parts = str.split(',');
+  return _.chain(parts)
+          .map(function(part){
+            if (part.indexOf('-') == -1) {
+              return [parseInt(part)];
+            } else {
+              range = part.split('-');
+              return _.range(parseInt(range[0]), parseInt(range[1])+1);
+            }
+          })
+          .flatten()
+          .uniq()
+          .value();
+}
+
 function convert(instream, outstream, mapfunc) {
   var outcsv = csv();
 
@@ -89,21 +105,9 @@ var Transformations = {
   // This is 0-indexed.
   cut: function(call){
     var columns = call[1] || "";
-    var parts = columns.split(',');
 
     // Convert the indices to ints
-    var idxes = _.chain(parts)
-                 .map(function(part){
-                   if (part.indexOf('-') == -1) {
-                     return [parseInt(part)];
-                   } else {
-                     range = part.split('-');
-                     return _.range(parseInt(range[0]), parseInt(range[1])+1);
-                   }
-                 })
-                 .flatten()
-                 .uniq()
-                 .value();
+    var idxes = toIntArr(columns);
 
     return function(row, index){
       if(index ==  'pre'){


### PR DESCRIPTION
Refs #37

I’ve removed sort().reverse() because they’re not needed with the current method (presumably an earlier solution involved removing columns on the fly, where a sort and reverse would have been necessary.)
