### PR TITLE
Hack to use multiple instances of optimist.

### DIFF
--- a/lib/operators.js
+++ b/lib/operators.js
@@ -1,14 +1,14 @@
 var inherits = require('util').inherits;
 var Transform = require('stream').Transform;
 var toIntArr = require('./tools').toIntArr;
+var optimist = require('./tools').optimist;
 var FixedQueue = require('./fixedqueue');
 var csv = require('csv');
 var _ = require('underscore');
-var optimist = require('optimist');
 
 var operators = {
   incsv: function(args) {
-    var argv = optimist
+    var argv = optimist()
       .options({
         d: {alias: 'delimiter', default: ',', string: true},
         e: {alias: 'encoding', default: 'utf-8', string: true},
@@ -41,7 +41,7 @@ var operators = {
   head: function(args) {
     Transform.call(this, {objectMode: true});
 
-    var argv = optimist
+    var argv = optimist()
       .options('n', {
         default: 10,
       })
@@ -56,7 +56,7 @@ var operators = {
   tail: function(args) {
     Transform.call(this, {objectMode: true});
 
-    var argv = optimist
+    var argv = optimist()
       .options('n', {
         default: '10',
         string: true
@@ -87,7 +87,7 @@ var operators = {
   cut: function(args) {
     Transform.call(this, {objectMode: true});
 
-    var argv = optimist
+    var argv = optimist()
       .boolean('complement')
       .parse(args)
     ;
@@ -104,7 +104,7 @@ var operators = {
   grep: function(args) {
     Transform.call(this, {objectMode: true});
 
-    var argv = optimist
+    var argv = optimist()
       .parse(args)
     ;
 
@@ -120,7 +120,7 @@ var operators = {
   delete: function(args) {
     Transform.call(this, {objectMode: true});
 
-    var argv = optimist
+    var argv = optimist()
       .parse(args)
     ;
 
@@ -132,7 +132,7 @@ var operators = {
   outcsv: function(args) {
     Transform.call(this, {objectMode: true});
 
-    var argv = optimist
+    var argv = optimist()
       .options({
         d: {alias: 'delimiter', default: ',', string: true},
         p: {alias: 'escapechar', default: '\\', string: true},

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -17,6 +17,11 @@ var tools = {
       .uniq()
       .value();
   },
+
+  optimist: function (){
+    delete require.cache[require.resolve('optimist')];
+    return require('optimist');
+  },
 };
 
 module.exports = tools;


### PR DESCRIPTION
We need to call optimist for each operation in a given pipeline. It is designed to be called once per script, so variables are not reset between calls, and lots of stale information appears in the returned argv object.

I don’t know if deleting from require.cache is ok, though…

I found this solution [on stackoverflow](http://stackoverflow.com/a/11477602). If there’s a better one, please let me know / apply it!
