### PR TITLE
Remove encoding option from csv parser; unify input/output csv options

### DIFF
--- a/lib/operators.js
+++ b/lib/operators.js
@@ -156,6 +156,7 @@ var operators = {
         q: {alias: 'quotechar', default: '\"', string: true},
         t: {alias: 'tabs', boolean: true},
         H: {alias: 'no-header-row', boolean: true},
+        S: {alias: 'skipinitialspace', boolean: true},
       })
       .parse(args)
     ;
@@ -168,6 +169,7 @@ var operators = {
       escape: argv.p,
       quote: argv.q,
     };
+    this._trimInitialSpace = argv.skipinitialspace;
   },
 
   // return our HTML transformation
@@ -325,6 +327,12 @@ inherits(operators.outcsv, Transform);
 operators.outcsv.prototype._transform = function(chunk, encoding, done) {
   var self = this;
   var row = JSON.parse(chunk).row;
+
+  if (this._trimInitialSpace) {
+    row = _.each(function(item) {
+      return item.trimLeft(item);
+    });
+  }
 
   csv()
     .from.array([row])


### PR DESCRIPTION
We will eventually need to reinstate some of this so we set the csv parser encoding, but (as @rgrp [points out here](https://github.com/okfn/datapipes/issues/12)) it should come from a query param so it can be applied to the input filestream as well.

Refs #12
