### PR TITLE
Stop streaming and respond once we’ve read enough.

### DIFF
--- a/lib/operators.js
+++ b/lib/operators.js
@@ -185,6 +185,8 @@ operators.head.prototype._transform = function(chunk, encoding, done) {
   if (this._lines < this._number) {
     this._lines += 1;
     this.push(chunk);
+  } else {
+    this.push(null);
   }
 
   done();


### PR DESCRIPTION
Aha! It turns out that pushing `null` downstream is enough to terminate the request and respond.

Unfortunately, the only operation that we can apply this to at present is `head`.

Refs #15.
