### PR TITLE
Use colon for both column and row ranges

### DIFF
--- a/docs/op-cut.md
+++ b/docs/op-cut.md
@@ -11,7 +11,7 @@ Remove specified columns from data.
 
     RANGE
         Comma separated column indices (0 based). Ranges can
-        also be specified with a hyphen.
+        also be specified with a colon.
 
 ### Examples
 
@@ -21,4 +21,4 @@ Delete the columns 0 and 3 of a CSV file:
 
 Delete the columns 1,3 and 5 to 10 of a CSV file:
 
-<a href="/csv/cut%201,3,5-10/?url=http://static.london.gov.uk/gla/expenditure/docs/2012-13-P12-250.csv">/csv/cut 1,3,5-10/?url=http://static.london.gov.uk/gla/expenditure/docs/2012-13-P12-250.csv</a>
+<a href="/csv/cut%201,3,5:10/?url=http://static.london.gov.uk/gla/expenditure/docs/2012-13-P12-250.csv">/csv/cut 1,3,5:10/?url=http://static.london.gov.uk/gla/expenditure/docs/2012-13-P12-250.csv</a>

--- a/lib/shorthandlist.js
+++ b/lib/shorthandlist.js
@@ -9,10 +9,10 @@ function ShorthandList(shorthand) {
 ShorthandList.prototype.expand = function() {
   return _.chain(this._shorthand)
     .map(function(part){
-      if (part.indexOf('-') == -1) {
+      if (part.indexOf(':') == -1) {
         return [parseInt(part)];
       } else {
-        var range = part.split('-');
+        var range = part.split(':');
         return _.range(parseInt(range[0]), parseInt(range[1])+1);
       }
     })

--- a/test/test.js
+++ b/test/test.js
@@ -208,7 +208,7 @@ describe('cut op', function(){
     });
   });
 
-  var url2 = '/csv/cut 0,2-4/?url=' + data_url;
+  var url2 = '/csv/cut 0,2:4/?url=' + data_url;
   describe('GET ' + url2, function(){
     var num_cols_removed = 4;
     it('should return csv with ' + (num_cols - num_cols_removed) + ' columns (' + num_cols_removed + ' removed)', function(done){
@@ -233,7 +233,7 @@ describe('cut op', function(){
     });
   });
 
-  var url3 = '/csv/cut 0,2-4 --complement/?url=' + data_url;
+  var url3 = '/csv/cut 0,2:4 --complement/?url=' + data_url;
   describe('GET ' + url2, function(){
     var num_cols_kept = 4;
     it('should return csv with ' + num_cols_kept + ' columns', function(done){


### PR DESCRIPTION
Refs #36.

Just doing a PR for this because it’s a diversion from the syntax unix `cut` uses.
