### PR TITLE
Replace %20s with nbsps in Chrome

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,10 +39,10 @@ app.configure(function(){
   app.set('port', process.env.PORT || 5000);
   app.set('views', __dirname + '/templates');
   app.use(express.logger('dev'));
+  app.use(chromeSpaceReplace);
   app.use(express.bodyParser());
   app.use(express.methodOverride());
   app.use(CORSSupport);
-  app.use(chromeSpaceReplace);
   app.use(express.static(path.join(__dirname, 'public')));
 });
 


### PR DESCRIPTION
Chrome makes URLs with spaces illegible:
![chrome](http://f.cl.ly/items/2J1N092F420g1z1v3a0l/Screen%20Shot%202013-11-26%20at%2013.14.40.png)

We replace these %20s with non-breaking spaces (which look normal) and then parse them as if they were spaces.

Refs #87.
