### PR TITLE
Replace spaces in path only – not query string!

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,8 +24,9 @@ var CORSSupport = function(req, res, next) {
 };
 
 var chromeSpaceReplace = function(req, res, next) {
+  var re = /(?:Windows|Macintosh).*?Chrome/;
   var agent = req.headers['user-agent'] || '';
-  if (agent.indexOf('Chrome') !== -1) {
+  if (re.test(agent)) {
     var parts = req.url.split('?');
     var datapipe = parts.shift();
     if (datapipe.indexOf('%20') !== -1) {

--- a/test/system.js
+++ b/test/system.js
@@ -44,7 +44,7 @@ describe('Chrome space replace', function(){
   it('should fix the %20 in the path, but not break the query string', function(done){
     request
       .get(url)
-      .set('user-agent', 'Chrome')
+      .set('user-agent', 'Windows Chrome')
       .expect(302)
       .end(function(err, res) {
         // %20 in path is fixed


### PR DESCRIPTION
This leaves %20s in the query string in tact.

Agree this definitely needs a test! Maybe don’t merge this until we’ve got one, as tests are lagging behind a bit!
