### PR TITLE
Restrict counter column excess spanning

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -512,6 +512,7 @@ table .counter, table tr:target .counter {
   background-image: none;
   border: none;
   text-align: right;
+  width: 1ch;
 }
 
 table .counter a {


### PR DESCRIPTION
The PR proposes to restrict the excessive span of column bearing row counters upon supplemental unoccupied space.

[![image](https://user-images.githubusercontent.com/16164426/75095363-e35c2900-55b9-11ea-902e-c43a9812ebd0.png)](http://datapipes.okfnlabs.org/csv/html/?url=https://gist.githubusercontent.com/ashenm/43792f25bc251175178af249bbee0769/raw/1582385824.csv?latest=true)

![image](https://user-images.githubusercontent.com/16164426/75095536-a4c76e00-55bb-11ea-9990-82b9a20ead3e.png)
